### PR TITLE
fix: correct typo in error message

### DIFF
--- a/src/handlers/onlineMultiplayerHandlers.js
+++ b/src/handlers/onlineMultiplayerHandlers.js
@@ -150,7 +150,7 @@ export const handleModalEnter = async (setState, currentState, messageHandler = 
     
     const { found } = await response.json();
     if (!found) {
-      throw new Error('Room doesnot exists');
+      throw new Error('Room does not exist');
     }
 
     // Try to connect to WebSocket using wsService


### PR DESCRIPTION
Fix typo in error message: `Room doesnot exists` → `Room does not exist`

Closes #1

Generated with [Claude Code](https://claude.ai/code)